### PR TITLE
correct version dependency for automake

### DIFF
--- a/net-fs/xtreemfs/xtreemfs-1.5.ebuild
+++ b/net-fs/xtreemfs/xtreemfs-1.5.ebuild
@@ -24,7 +24,7 @@ DEPEND=">=virtual/jdk-1.6.0
   dev-java/ant-core
   sys-apps/attr
   >=dev-libs/boost-1.39.0
-  =sys-devel/automake-1.11.6"
+  ~sys-devel/automake-1.11.6"
 
 RDEPEND="${DEPEND}"
 

--- a/net-fs/xtreemfs/xtreemfs-9999.ebuild
+++ b/net-fs/xtreemfs/xtreemfs-9999.ebuild
@@ -23,7 +23,7 @@ DEPEND=">=virtual/jdk-1.6.0
   dev-java/ant-core
   sys-apps/attr
   >=dev-libs/boost-1.39.0
-  =sys-devel/automake-1.11.6"
+  ~sys-devel/automake-1.11.6"
 
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Since the required automake version got a revision number, this must be handled in the dependencies.